### PR TITLE
add Tick() method

### DIFF
--- a/core/engine.go
+++ b/core/engine.go
@@ -10,4 +10,5 @@ type Engine interface {
 	Run()
 	Setup()
 	Teardown()
+	Tick()
 }

--- a/engines/default_engine.go
+++ b/engines/default_engine.go
@@ -25,6 +25,13 @@ func (e *defaultEngine) Run() {
 	}
 }
 
+// Tick calls the Process() method for each System exactly once
+func (e *defaultEngine) Tick() {
+	for _, system := range e.systemManager.Systems() {
+		state := system.Process(e.entityManager)
+	}
+}
+
 // Setup calls the Setup() method for each System
 // and initializes ShouldEngineStop and ShouldEnginePause with false.
 func (e *defaultEngine) Setup() {


### PR DESCRIPTION
This method calls Process() on each System exactly once. This is necessary if you are using this ECS library with another game engine that has its own control loop (e.g. ebitengine)